### PR TITLE
avoid relative path in loading codemirror

### DIFF
--- a/lib/show-invisibles.js
+++ b/lib/show-invisibles.js
@@ -5,9 +5,9 @@
     'use strict';
     
     if (typeof exports === 'object' && typeof module === 'object') // CommonJS
-        mod(require('../../lib/codemirror'));
+        mod(require('codemirror/lib/codemirror'));
     else if (typeof define === 'function' && define.amd) // AMD
-        define(['../../lib/codemirror'], mod);
+        define(['codemirror/lib/codemirror'], mod);
     else
         mod(CodeMirror);
 })(function(CodeMirror) {


### PR DESCRIPTION
We found the relative path does not work in some certain scenarios.

For example, when installing using bower inside codemirror, by default it will be installed under codermirror/app/components, which will make the relative path fail.

In addition, in our use case we want to install this addon as another bower components same as codemirror, using relative path prevent us from doing that.

By using absolute path, the user can define where their codemirror is installed and use that to call the requireJS API to configure the path:
`requirejs.config({
    paths: {
        codemirror: '../components/codemirror'
    }
});`

